### PR TITLE
Add ability for developers to specify a throttle policy.

### DIFF
--- a/PasscodeLock.xcodeproj/project.pbxproj
+++ b/PasscodeLock.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D47A0771D7912C2006D381B /* ThrottlePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D47A0761D7912C2006D381B /* ThrottlePolicy.swift */; };
 		4D47A0791D7912DB006D381B /* EventSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D47A0781D7912DB006D381B /* EventSubscriber.swift */; };
 		C99EAF431B90B05700D61E1B /* PasscodeLock.h in Headers */ = {isa = PBXBuildFile; fileRef = C99EAF421B90B05700D61E1B /* PasscodeLock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C99EAF4A1B90B05800D61E1B /* PasscodeLock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C99EAF3F1B90B05700D61E1B /* PasscodeLock.framework */; };
@@ -107,6 +108,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4D47A0761D7912C2006D381B /* ThrottlePolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrottlePolicy.swift; sourceTree = "<group>"; };
 		4D47A0781D7912DB006D381B /* EventSubscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventSubscriber.swift; sourceTree = "<group>"; };
 		C99EAF3F1B90B05700D61E1B /* PasscodeLock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PasscodeLock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C99EAF421B90B05700D61E1B /* PasscodeLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PasscodeLock.h; sourceTree = "<group>"; };
@@ -237,6 +239,7 @@
 				C9DC07FA1B90D0A3007A4DD0 /* PasscodeLock.strings */,
 				C9DC08151B90DF4E007A4DD0 /* PasscodeLockViewController.swift */,
 				C9D3DF471B91F099008561EB /* PasscodeLockPresenter.swift */,
+				4D47A0761D7912C2006D381B /* ThrottlePolicy.swift */,
 				4D47A0781D7912DB006D381B /* EventSubscriber.swift */,
 			);
 			path = PasscodeLock;
@@ -557,6 +560,7 @@
 				4D47A0791D7912DB006D381B /* EventSubscriber.swift in Sources */,
 				C9D3DF481B91F099008561EB /* PasscodeLockPresenter.swift in Sources */,
 				C9DC07D81B90B261007A4DD0 /* PasscodeLockStateType.swift in Sources */,
+				4D47A0771D7912C2006D381B /* ThrottlePolicy.swift in Sources */,
 				C9DC08161B90DF4E007A4DD0 /* PasscodeLockViewController.swift in Sources */,
 				C9DC07E11B90BBFD007A4DD0 /* PasscodeLock.swift in Sources */,
 				C9DC07F81B90CF29007A4DD0 /* Functions.swift in Sources */,

--- a/PasscodeLock/PasscodeLock/ConfirmPasscodeState.swift
+++ b/PasscodeLock/PasscodeLock/ConfirmPasscodeState.swift
@@ -39,7 +39,7 @@ struct ConfirmPasscodeState: PasscodeLockStateType {
             let nextState = SetPasscodeState(title: mismatchTitle, description: mismatchDescription)
             
             lock.changeStateTo(nextState)
-            lock.delegate?.passcodeLockDidFail(lock)
+            lock.delegate?.passcodeLockDidFail(lock, reason: .IncorrectPasscode)
         }
     }
 }

--- a/PasscodeLock/PasscodeLock/PasscodeLock.swift
+++ b/PasscodeLock/PasscodeLock/PasscodeLock.swift
@@ -89,7 +89,7 @@ public class PasscodeLock: PasscodeLockType {
         dispatch_async(dispatch_get_main_queue()) {
             
             if success {
-                
+                self.configuration.throttlePolicy.markSuccess()
                 self.delegate?.passcodeLockDidSucceed(self)
             }
         }

--- a/PasscodeLock/PasscodeLockViewController.swift
+++ b/PasscodeLock/PasscodeLockViewController.swift
@@ -255,6 +255,19 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
         
         placeholders[index].animateState(state)
     }
+    
+    func showThrottleMessage(message: ThrottleMessage) {
+        let alertController = UIAlertController(title: message.title,
+                                                message: message.body,
+                                                preferredStyle: .Alert)
+        
+        
+        let OKAction = UIAlertAction(title: "OK", style: .Default, handler: nil)
+        alertController.addAction(OKAction)
+        
+        self.presentViewController(alertController, animated: true) {
+        }
+    }
 
     // MARK: - PasscodeLockDelegate
     
@@ -266,9 +279,16 @@ public class PasscodeLockViewController: UIViewController, PasscodeLockTypeDeleg
         })
     }
     
-    public func passcodeLockDidFail(lock: PasscodeLockType) {
-        
-        animateWrongPassword()
+    public func passcodeLockDidFail(lock: PasscodeLockType, reason: PasscodeFailureReason) {
+        switch reason {
+        case .IncorrectPasscode:
+            animateWrongPassword()
+        case .Throttled:
+            showThrottleMessage(lock.configuration.throttlePolicy.message)
+            animateWrongPassword()
+        default:
+            animateWrongPassword()
+        }
     }
     
     public func passcodeLockDidChangeState(lock: PasscodeLockType) {

--- a/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
+++ b/PasscodeLock/Protocols/PasscodeLockConfigurationType.swift
@@ -9,11 +9,10 @@
 import Foundation
 
 public protocol PasscodeLockConfigurationType {
-    
-    var repository: PasscodeRepositoryType {get}
-    var passcodeLength: Int {get}
-    var isTouchIDAllowed: Bool {get set}
-    var shouldRequestTouchIDImmediately: Bool {get}
-    var touchIdReason: String? {get set}
-    var maximumInccorectPasscodeAttempts: Int {get}
+    var throttlePolicy: ThrottlePolicy { get }
+    var repository: PasscodeRepositoryType { get }
+    var passcodeLength: Int { get }
+    var isTouchIDAllowed: Bool { get set }
+    var shouldRequestTouchIDImmediately: Bool { get }
+    var touchIdReason: String? { get set }
 }

--- a/PasscodeLock/Protocols/PasscodeLockType.swift
+++ b/PasscodeLock/Protocols/PasscodeLockType.swift
@@ -22,10 +22,16 @@ public protocol PasscodeLockType {
     func authenticateWithBiometrics()
 }
 
+public enum PasscodeFailureReason {
+    case Throttled
+    case IncorrectPasscode
+    case RepositoryHasNoPasscode
+}
+
 public protocol PasscodeLockTypeDelegate: class {
     
     func passcodeLockDidSucceed(lock: PasscodeLockType)
-    func passcodeLockDidFail(lock: PasscodeLockType)
+    func passcodeLockDidFail(lock: PasscodeLockType, reason: PasscodeFailureReason)
     func passcodeLockDidChangeState(lock: PasscodeLockType)
     func passcodeLock(lock: PasscodeLockType, addedSignAtIndex index: Int)
     func passcodeLock(lock: PasscodeLockType, removedSignAtIndex index: Int)

--- a/PasscodeLock/ThrottlePolicy.swift
+++ b/PasscodeLock/ThrottlePolicy.swift
@@ -1,0 +1,38 @@
+//
+//  ThrottlePolicy.swift
+//  PasscodeLock
+//
+//  Created by Mark Hudnall on 9/1/16.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//
+
+import Foundation
+
+public struct ThrottleMessage {
+    let title: String?
+    let body: String
+    
+    public init(title: String?, body: String) {
+        self.title = title
+        self.body = body
+    }
+}
+
+public protocol ThrottlePolicy {
+    var isThrottled: Bool { get }
+    var throttleRemovedAt: NSTimeInterval { get }
+    var message: ThrottleMessage { get }
+    func markSuccess() -> Void
+    func markFailure() -> Void
+}
+
+public struct NoThrottlePolicy: ThrottlePolicy {
+    public let isThrottled: Bool = false
+    public let throttleRemovedAt: NSTimeInterval = -1
+    public var message: ThrottleMessage = ThrottleMessage(title: nil,
+                                                   body: "This message should never be shown because this policy does no throttling.")
+    public func markFailure() { }
+    public func markSuccess() { }
+    
+    public init() {}
+}


### PR DESCRIPTION
This PR replaces the notion of "maximumIncorrectPasscodeAttempts". It
introduces the concept of a ThrottlePolicy, which determines how passcode
entry should be throttled. Developers must pass a ThrottlePolicy into
configuration. This PR also provides an implementation of ThrottlePolicy,
NoThrottlePolicy, which does not do any throttling.
