### PR TITLE
Make subscribing for foreground/background events optional

### DIFF
--- a/PasscodeLock.xcodeproj/project.pbxproj
+++ b/PasscodeLock.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4D47A0791D7912DB006D381B /* EventSubscriber.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D47A0781D7912DB006D381B /* EventSubscriber.swift */; };
 		C99EAF431B90B05700D61E1B /* PasscodeLock.h in Headers */ = {isa = PBXBuildFile; fileRef = C99EAF421B90B05700D61E1B /* PasscodeLock.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C99EAF4A1B90B05800D61E1B /* PasscodeLock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C99EAF3F1B90B05700D61E1B /* PasscodeLock.framework */; };
 		C9D3DF0B1B919CE4008561EB /* PasscodeLockView.xib in Resources */ = {isa = PBXBuildFile; fileRef = C9D3DF0A1B919CE4008561EB /* PasscodeLockView.xib */; };
@@ -106,6 +107,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4D47A0781D7912DB006D381B /* EventSubscriber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventSubscriber.swift; sourceTree = "<group>"; };
 		C99EAF3F1B90B05700D61E1B /* PasscodeLock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PasscodeLock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C99EAF421B90B05700D61E1B /* PasscodeLock.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PasscodeLock.h; sourceTree = "<group>"; };
 		C99EAF441B90B05700D61E1B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				C9DC07FA1B90D0A3007A4DD0 /* PasscodeLock.strings */,
 				C9DC08151B90DF4E007A4DD0 /* PasscodeLockViewController.swift */,
 				C9D3DF471B91F099008561EB /* PasscodeLockPresenter.swift */,
+				4D47A0781D7912DB006D381B /* EventSubscriber.swift */,
 			);
 			path = PasscodeLock;
 			sourceTree = "<group>";
@@ -551,6 +554,7 @@
 				C9DC08121B90DE1B007A4DD0 /* PasscodeSignPlaceholderView.swift in Sources */,
 				C9DC07F21B90C9DE007A4DD0 /* EnterPasscodeState.swift in Sources */,
 				C9DC08141B90DE50007A4DD0 /* PasscodeSignButton.swift in Sources */,
+				4D47A0791D7912DB006D381B /* EventSubscriber.swift in Sources */,
 				C9D3DF481B91F099008561EB /* PasscodeLockPresenter.swift in Sources */,
 				C9DC07D81B90B261007A4DD0 /* PasscodeLockStateType.swift in Sources */,
 				C9DC08161B90DF4E007A4DD0 /* PasscodeLockViewController.swift in Sources */,

--- a/PasscodeLock/EventSubscriber.swift
+++ b/PasscodeLock/EventSubscriber.swift
@@ -1,0 +1,42 @@
+//
+//  EventSubscriber.swift
+//  PasscodeLock
+//
+//  Created by Mark Hudnall on 9/1/16.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//
+
+import Foundation
+
+class EventSubscriber {
+    weak var target: AnyObject?
+    let selector: Selector
+    let eventName: String
+    let object: AnyObject?
+    
+    let notificationCenter: NSNotificationCenter
+    
+    init(target: AnyObject,
+         selector: Selector,
+         eventName: String,
+         object: AnyObject? = nil,
+         notificationCenter: NSNotificationCenter = NSNotificationCenter.defaultCenter()) {
+        self.target = target
+        self.selector = selector
+        self.eventName = eventName
+        self.object = object
+        self.notificationCenter = notificationCenter
+    }
+    
+    func unsubscribe() {
+        self.notificationCenter.removeObserver(self)
+    }
+    
+    func subscribe() {
+        self.notificationCenter.addObserver(self, selector: #selector(handleEvent), name: self.eventName, object: self.object)
+    }
+    
+    @objc func handleEvent(notification: NSNotification) {
+        target?.performSelector(self.selector, withObject: notification)
+    }
+}


### PR DESCRIPTION
This lets us use the PasscodeLockViewController in situations other than
the first window that is displayed upon app open. For an example,
consider an app that requires passcode authentication for certain
actions, and which keeps the passcode view controller around. With
events always enabled, the passcode view controller would trigger
biometric login even if it were not being displayed.
